### PR TITLE
Fix goto_track call expecting a int parameter

### DIFF
--- a/custom_components/ytube_music_player/media_player.py
+++ b/custom_components/ytube_music_player/media_player.py
@@ -1787,8 +1787,8 @@ class yTubeMusicComponent(MediaPlayerEntity):
 			self._name = self._org_name + " - " + str(self._attributes['likeStatus'])
 			self.log_me('debug', "Showing like status in name until restart")
 		elif(command == SERVICE_CALL_GOTO_TRACK):
-			self.log_me('debug', "Going to Track " + str(parameters) + ".")
-			self._next_track_no = min(max(int(parameters) - 1 - 1, -1), len(self._tracks) - 1)
+			self.log_me('debug', "Going to Track " + str(all_params[0]) + ".")
+			self._next_track_no = min(max(int(all_params[0]) - 1 - 1, -1), len(self._tracks) - 1)
 			prev_shuffle = self._shuffle  # store current shuffle setting
 			self._shuffle = False  # set false, otherwise async_get_track will override next_track
 			await self.async_get_track()


### PR DESCRIPTION
Fixes support for a call like
```
service: ytube_music_player.call_method
data:
  entity_id: media_player.ytube_music_player
  command: goto_track
  parameters: '{{ state_attr("media_player.ytube_music_player", "current_track")+2 }}'
```

to skip a track without spitting out the error:

> TypeError: int() argument must be a string, a bytes-like object or a real number, not 'list'
> 2022-08-02 20:43:21 ERROR (MainThread) [homeassistant.components.websocket_api.http.connection] [140136941094224] Error handling message: Unknown error (unknown_error)
> Traceback (most recent call last):
>   File "/usr/src/homeassistant/homeassistant/components/websocket_api/decorators.py", line 27, in _handle_async_response
>     await func(hass, connection, msg)
>   File "/usr/src/homeassistant/homeassistant/components/websocket_api/commands.py", line 636, in handle_execute_script
>     await script_obj.async_run(msg.get("variables"), context=context)
>   File "/usr/src/homeassistant/homeassistant/helpers/script.py", line 1513, in async_run
>     await asyncio.shield(run.async_run())
>   File "/usr/src/homeassistant/homeassistant/helpers/script.py", line 405, in async_run
>     await self._async_step(log_exceptions=False)
>   File "/usr/src/homeassistant/homeassistant/helpers/script.py", line 449, in _async_step
>     self._handle_exception(
>   File "/usr/src/homeassistant/homeassistant/helpers/script.py", line 472, in _handle_exception
>     raise exception
>   File "/usr/src/homeassistant/homeassistant/helpers/script.py", line 447, in _async_step
>     await getattr(self, handler)()
>   File "/usr/src/homeassistant/homeassistant/helpers/script.py", line 680, in _async_call_service_step
>     await service_task
>   File "/usr/src/homeassistant/homeassistant/core.py", line 1713, in async_call
>     task.result()
>   File "/usr/src/homeassistant/homeassistant/core.py", line 1750, in _execute_service
>     await cast(Callable[[ServiceCall], Awaitable[None]], handler.job.target)(
>   File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 719, in handle_service
>     await service.entity_service_call(
>   File "/usr/src/homeassistant/homeassistant/helpers/service.py", line 680, in entity_service_call
>     future.result()  # pop exception if have
>   File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 930, in async_request_call
>     await coro
>   File "/usr/src/homeassistant/homeassistant/helpers/service.py", line 717, in _handle_entity_call
>     await result
>   File "/config/custom_components/ytube_music_player/media_player.py", line 1789, in async_call_method
>     self._next_track_no = min(max(int(parameters) - 1 - 1, -1), len(self._tracks) - 1)
> TypeError: int() argument must be a string, a bytes-like object or a real number, not 'list'