### PR TITLE
Add URL shortener proxy API endpoint

### DIFF
--- a/custom_components/ytube_music_player/__init__.py
+++ b/custom_components/ytube_music_player/__init__.py
@@ -1,5 +1,7 @@
 """Provide the initial setup."""
 import logging
+
+from . import http_api
 from .const import *
 
 _LOGGER = logging.getLogger(__name__)
@@ -7,6 +9,7 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup(hass, config):
 	"""Provide Setup of platform."""
+	await http_api.async_setup(hass)
 	return True
 
 

--- a/custom_components/ytube_music_player/__init__.py
+++ b/custom_components/ytube_music_player/__init__.py
@@ -1,7 +1,5 @@
 """Provide the initial setup."""
 import logging
-
-from . import http_api
 from .const import *
 
 _LOGGER = logging.getLogger(__name__)
@@ -9,7 +7,6 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup(hass, config):
 	"""Provide Setup of platform."""
-	await http_api.async_setup(hass)
 	return True
 
 
@@ -21,6 +18,11 @@ async def async_setup_entry(hass, config_entry):
 
 	hass.data.setdefault(DOMAIN, {})
 	hass.data[DOMAIN][config_entry.entry_id] = {}
+
+	# only register our endpoint on demand if we have a player configured for it
+	if config_entry.data[CONF_PROXY_REDIR]:
+		from . import http_api
+		await http_api.async_setup(hass)
 
 	# Add sensor
 	for platform in PLATFORMS:

--- a/custom_components/ytube_music_player/config_flow.py
+++ b/custom_components/ytube_music_player/config_flow.py
@@ -159,6 +159,7 @@ async def async_create_form(hass, user_input, page=1):
 
 		data_schema[vol.Optional(CONF_PROXY_PATH, default=user_input[CONF_PROXY_PATH])] = str # select of input_boolean -> continuous on/off
 		data_schema[vol.Optional(CONF_PROXY_URL, default=user_input[CONF_PROXY_URL])] = str # select of input_boolean -> continuous on/off
+		data_schema[vol.Optional(CONF_PROXY_REDIR, default=user_input[CONF_PROXY_REDIR])] = vol.Coerce(bool) # enable local redir for long urls
 
 	return data_schema
 

--- a/custom_components/ytube_music_player/config_flow.py
+++ b/custom_components/ytube_music_player/config_flow.py
@@ -116,6 +116,13 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 			self._errors = await async_check_data(self.hass,user_input)
 			if self._errors == {}:
 				self.data.update(user_input)
+
+				# enable the short proxy endpoint if we were conifgured with it
+				if self.data[CONF_PROXY_REDIR]:
+					from . import http_api
+					await http_api.async_setup(self.hass)
+
+
 				return self.async_create_entry(title="yTubeMusic "+self.data[CONF_NAME].replace(DOMAIN,''), data=self.data)
 		elif self.data is not None:
 			# if we came straight from init

--- a/custom_components/ytube_music_player/const.py
+++ b/custom_components/ytube_music_player/const.py
@@ -144,6 +144,7 @@ SERVICE_CALL_PAUSED_IS_IDLE = "paused_is_idle"
 SERIVCE_CALL_DEBUG_AS_ERROR = "debug_as_error"
 SERVICE_CALL_LIKE_IN_NAME = "like_in_name"
 SERVICE_CALL_GOTO_TRACK = "goto_track"
+URL_PROXY_SHORT = "/api/ytmp/s/{player_name}/{key}"
 
 
 CONF_RECEIVERS = 'speakers'	 # list of speakers (media_players)
@@ -162,6 +163,7 @@ CONF_INIT_EXTRA_SENSOR = 'extra_sensor'
 CONF_TRACK_LIMIT = 'track_limit'
 CONF_PROXY_URL = 'proxy_url'
 CONF_PROXY_PATH = 'proxy_path'
+CONF_PROXY_REDIR = 'proxy_redir'
 
 CONF_SELECT_SOURCE = 'select_source'
 CONF_SELECT_PLAYLIST = 'select_playlist'
@@ -361,6 +363,7 @@ def ensure_config(user_input):
 	out[CONF_LEGACY_RADIO] = DEFAULT_LEGACY_RADIO
 	out[CONF_SORT_BROWSER] = DEFAULT_SORT_BROWSER
 	out[CONF_INIT_EXTRA_SENSOR] = DEFAULT_INIT_EXTRA_SENSOR
+	out[CONF_PROXY_REDIR] = False
 
 	if user_input is not None:
 		out.update(user_input)

--- a/custom_components/ytube_music_player/const.py
+++ b/custom_components/ytube_music_player/const.py
@@ -144,6 +144,7 @@ SERVICE_CALL_PAUSED_IS_IDLE = "paused_is_idle"
 SERIVCE_CALL_DEBUG_AS_ERROR = "debug_as_error"
 SERVICE_CALL_LIKE_IN_NAME = "like_in_name"
 SERVICE_CALL_GOTO_TRACK = "goto_track"
+DOMAIN_PROXY_REDIR_URL = "short_proxy_url"
 URL_PROXY_SHORT = "/api/ytmp/s/{player_name}/{key}"
 
 

--- a/custom_components/ytube_music_player/http_api.py
+++ b/custom_components/ytube_music_player/http_api.py
@@ -1,0 +1,75 @@
+"""HTTP API hooks for youtube music player."""
+
+import logging
+from typing import cast
+
+from aiohttp import web
+from homeassistant.components.http import HomeAssistantView
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_platform
+from homeassistant.helpers.network import get_url
+
+from .const import DOMAIN, URL_PROXY_SHORT
+from .media_player import yTubeMusicComponent
+
+
+_LOGGER = logging.getLogger(__name__)
+
+async def async_setup(hass: HomeAssistant) -> None:
+	"""Handles setup for HTTP API endpoints."""
+	hass.http.register_view(YTubeShortProxyView)
+
+	hass.data.setdefault(DOMAIN, {})
+	hass.data[DOMAIN]["short_proxy_url"] = await get_proxy_url(hass)
+
+	_LOGGER.info("registered short proxy redirector")
+
+class YTubeShortProxyView(HomeAssistantView):
+	"""Simple view to handle searching for and sending a redirect for a URL."""
+	name = "api:ytube:short-proxy"
+	requires_auth = False
+	url: str = URL_PROXY_SHORT
+
+	async def get(self, request: web.Request, player_name: str, key: str) -> None:
+		"""Handles the GET request to find a proxied URL."""
+		hass: HomeAssistant = request.app["hass"]
+		_LOGGER.debug("request for key %s for player %s", key, player_name)
+
+		if key is None or player_name is None:
+			_LOGGER.info("key or player not found. player: %s, key: %s", player_name, key)
+			raise web.HTTPNotFound()
+
+		mp = await get_music_player_instance(hass, player_name)
+		if mp is None:
+			_LOGGER.info("could not find matching media player: %s", player_name)
+			raise web.HTTPNotFound()
+
+		if not mp._proxy_redir:
+			_LOGGER.info("proxy_redir not enabled for player %s", mp)
+			raise web.HTTPBadRequest()
+
+		url = mp._proxy_redir_dict.get(key)
+		if url is None:
+			raise web.HTTPNotFound()
+
+		raise web.HTTPFound(url)
+
+async def get_music_player_instance(hass: HomeAssistant, player_name: str) -> yTubeMusicComponent | None:
+	"""Finds the requested music player instance in the ytube_music_player platform."""
+	entities = entity_platform.async_get_platforms(hass, 'ytube_music_player')
+	media_player_domain = [*filter(lambda e: e.domain == "media_player", entities)]
+	if len(media_player_domain) != 1:
+		_LOGGER.warning("found more than one domain in the ytube_music_player platform")
+		return None
+
+	media_players = cast(dict[str, yTubeMusicComponent], media_player_domain[0].entities)
+	return media_players.get(player_name)
+
+async def get_proxy_url(hass: HomeAssistant) -> str:
+	"""Gets the full proxy url base used to send to music players."""
+	url = get_url(hass)
+	url += URL_PROXY_SHORT
+
+	return url
+
+# vim:sw=4:sts=4:ts=4:noet

--- a/custom_components/ytube_music_player/media_player.py
+++ b/custom_components/ytube_music_player/media_player.py
@@ -113,7 +113,7 @@ class yTubeMusicComponent(MediaPlayerEntity):
 		self._proxy_url = config.data.get(CONF_PROXY_URL, "")
 		self._proxy_path = config.data.get(CONF_PROXY_PATH, "")
 		self._proxy_redir = config.data.get(CONF_PROXY_REDIR, False)
-		self._proxy_redir_url = hass.data[DOMAIN]["short_proxy_url"]
+		self._proxy_redir_url = hass.data[DOMAIN].get(DOMAIN_PROXY_REDIR_URL, "")
 		self._proxy_redir_dict = {}
 
 
@@ -130,6 +130,8 @@ class yTubeMusicComponent(MediaPlayerEntity):
 		self.log_me('debug', "- like_in_name: " + str(self._like_in_name))
 		self.log_me('debug', "- track_limit: " + str(self._trackLimit))
 		self.log_me('debug', "- legacy_radio: " + str(self._legacyRadio))
+		self.log_me('debug', "- short proxy enabed: " + str(self._proxy_redir))
+		self.log_me('debug', "- short proxy url: " + str(self._proxy_redir_url))
 
 		self._brand_id = str(config.data.get(CONF_BRAND_ID, ""))
 		self._api = None

--- a/custom_components/ytube_music_player/translations/en.json
+++ b/custom_components/ytube_music_player/translations/en.json
@@ -29,7 +29,8 @@
                     "track_limit": "Limit of simultaneously loaded tracks",
                     "legacy_radio": "Create radio as watchlist of random playlist track",
                     "sort_browser": "Sort results in the media browser",
-                    "extra_sensor": "Create sensor that provide extra information"
+                    "extra_sensor": "Create sensor that provide extra information",
+                    "proxy_redir": "Enable alternate local proxy to redirect long URLs"
                 }
             }
         },
@@ -72,7 +73,8 @@
                     "track_limit": "Limit of simultaneously loaded tracks",
                     "legacy_radio": "Create radio as watchlist of random playlist track",
                     "sort_browser": "Sort results in the media browser",
-                    "extra_sensor": "Create sensor that provide extra information"
+                    "extra_sensor": "Create sensor that provide extra information",
+                    "proxy_redir": "Enable alternate local proxy to redirect long URLs"
                 }
             }
         },


### PR DESCRIPTION
The final decoded URLs are too long for Denon AVR devices using the HEOS command line interface. The underlying CLI system has a maximum of 512 bytes for the URL passed in to the `heos://browse/play_stream` command and anything over that will crash the HEOS service abruptly (is there any other kind) and require a reconnection to send commands.

This adds an optional advanced configuration to enable an API endpoint for Home Assistant to act as a simple redirect proxy by creating a much shorter URL that will issue a 302 redirect to the real service. It turns out the underlying player _can_ handle a longer URL but not via the HEOS command.

The player adds a redirect dictionary to allow for a mapping of the MD5 of the final URL to the URL itself and replaces the URL with `/api/ytmp/s/{player-id}/{md5}` and sends that to the player instead. The API endpoint then extracts the player object and finds the appropriate URL to send as a redirect. When the YouTube Music player is turned off the cache is cleared, being an easy compromise to keep the cache under control without adding overheads of tracking the age of the URL and periodically cleaning them out. Of course, if you never turn off the player it will grow unbounded until Home Assistant is restarted.

An earlier implementation of this created a new `aiohttp` server on another port, which worked for me locally but may have had issues running in the full docker environment and by enabling the API endpoint it technically works with the cloud service and any HTTPS endpoints you may have configured. I have no idea how it would handle a self-signed cerificate though, so that may still be an issue.