### PR TITLE
Fix goto_track - treat parameters as array, not string

### DIFF
--- a/custom_components/ytube_music_player/media_player.py
+++ b/custom_components/ytube_music_player/media_player.py
@@ -1789,8 +1789,8 @@ class yTubeMusicComponent(MediaPlayerEntity):
 			self._name = self._org_name + " - " + str(self._attributes['likeStatus'])
 			self.log_me('debug', "Showing like status in name until restart")
 		elif(command == SERVICE_CALL_GOTO_TRACK):
-			self.log_me('debug', "Going to Track " + str(parameters) + ".")
-			self._next_track_no = min(max(int(parameters) - 1 - 1, -1), len(self._tracks) - 1)
+			self.log_me('debug', "Going to Track " + str(parameters[0]) + ".")
+			self._next_track_no = min(max(int(parameters[0]) - 1 - 1, -1), len(self._tracks) - 1)
 			prev_shuffle = self._shuffle  # store current shuffle setting
 			self._shuffle = False  # set false, otherwise async_get_track will override next_track
 			await self.async_get_track()


### PR DESCRIPTION
goto_track doesn't work right now because `parameters` is assume to be a string or int when it's actually an array (tested on 2023.12). This change grabs the first element out of parameters. 