### PR TITLE
Add ytmusicapi language option.

### DIFF
--- a/custom_components/ytube_music_player/browse_media.py
+++ b/custom_components/ytube_music_player/browse_media.py
@@ -495,6 +495,9 @@ async def build_item_response(ytmusicplayer, payload):
 					))
 				elif(a['resultType'] == 'artist'):
 					_LOGGER.debug("a: %s", a)
+					if not('artist' in a):
+						a['artist'] = a['artists'][0]['name']  # Fix Top result
+						a['browseId'] = a['artists'][0]['id']  # Fix Top result
 					children.append(BrowseMedia(
 						title = helper.get(a['resultType'], "") + a['artist'], # noqa: E251
 						media_class = MediaClass.ARTIST,					  # noqa: E251

--- a/custom_components/ytube_music_player/config_flow.py
+++ b/custom_components/ytube_music_player/config_flow.py
@@ -184,7 +184,8 @@ async def async_create_form(hass, user_input, page=1):
 	"""Create form for UI setup."""
 	user_input = ensure_config(user_input)
 	data_schema = OrderedDict()
-	
+	languages = ["ar", "de", "en", "es", "fr", "hi", "it", "ja", "ko", "nl", "pt", "ru", "tr", "ur", "zh_CN", "zh_TW"]
+
 	if(page == 1):
 		data_schema[vol.Required(CONF_CODE+"TT", default="https://www.google.com/device?user_code="+user_input[CONF_CODE]["user_code"])] = str # name of the component without domain
 		data_schema[vol.Required(CONF_NAME, default=user_input[CONF_NAME])] = str # name of the component without domain
@@ -196,6 +197,12 @@ async def async_create_form(hass, user_input, page=1):
 					"exclude_entities": [DOMAIN_MP+"."+user_input[CONF_NAME]]
                 }
             })
+		data_schema[vol.Required(CONF_API_LANGUAGE, default=user_input[CONF_API_LANGUAGE])] = selector({
+				"select": {
+					"options": languages,
+					"mode": "dropdown"
+				}
+			})
 		data_schema[vol.Required(CONF_HEADER_PATH, default=user_input[CONF_HEADER_PATH])] = str # file path of the header
 		data_schema[vol.Required(CONF_ADVANCE_CONFIG, default=user_input[CONF_ADVANCE_CONFIG])] = vol.Coerce(bool) # show page 2
 

--- a/custom_components/ytube_music_player/const.py
+++ b/custom_components/ytube_music_player/const.py
@@ -109,6 +109,7 @@ SERVICE_CALL_APPEND_TRACK = "append_track_to_queue"
 
 CONF_RECEIVERS = 'speakers'	 # list of speakers (media_players)
 CONF_HEADER_PATH = 'header_path'
+CONF_API_LANGUAGE = 'api_language'
 CONF_SHUFFLE = 'shuffle'
 CONF_SHUFFLE_MODE = 'shuffle_mode'
 CONF_COOKIE = 'cookie'
@@ -138,6 +139,7 @@ DEFAULT_SELECT_PLAYLIST = "" #input_select.DOMAIN + "." + DOMAIN + '_playlist' #
 DEFAULT_SELECT_PLAYMODE = "" #input_select.DOMAIN + "." + DOMAIN + '_playmode' # cleared defaults to avoid further issues with multiple instances
 DEFAULT_SELECT_SPEAKERS = "" #input_select.DOMAIN + "." + DOMAIN + '_speakers' # cleared defaults to avoid further issues with multiple instances
 DEFAULT_HEADER_FILENAME = 'header_'
+DEFAULT_API_LANGUAGE = 'en'
 DEFAULT_LIKE_IN_NAME = False
 DEFAULT_DEBUG_AS_ERROR = False
 DEFAULT_INIT_EXTRA_SENSOR = False
@@ -241,7 +243,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 
-async def async_try_login(hass, path, brand_id):
+async def async_try_login(hass, path, brand_id, language='en'):
 	ret = {}
 	api = None
 	msg = ""
@@ -249,10 +251,10 @@ async def async_try_login(hass, path, brand_id):
 	try:
 		if(brand_id!=""):
 			_LOGGER.debug("- using brand ID: "+brand_id)
-			api = await hass.async_add_executor_job(YTMusic,path,brand_id)
+			api = await hass.async_add_executor_job(YTMusic,path,brand_id,None,None,language)
 		else:
 			_LOGGER.debug("- login without brand ID and credential at path "+path)
-			api = await hass.async_add_executor_job(YTMusic,path)
+			api = await hass.async_add_executor_job(YTMusic,path,None,None,None,language)
 	except KeyError as err:
 		_LOGGER.debug("- Key exception")
 		if(str(err)=="'contents'"):
@@ -312,6 +314,7 @@ def ensure_config(user_input):
 	"""Make sure that needed Parameter exist and are filled with default if not."""
 	out = {}
 	out[CONF_NAME] = DOMAIN
+	out[CONF_API_LANGUAGE] = DEFAULT_API_LANGUAGE
 	out[CONF_RECEIVERS] = ''
 	out[CONF_SHUFFLE] = DEFAULT_SHUFFLE
 	out[CONF_SHUFFLE_MODE] = DEFAULT_SHUFFLE_MODE

--- a/custom_components/ytube_music_player/media_player.py
+++ b/custom_components/ytube_music_player/media_player.py
@@ -84,6 +84,7 @@ class yTubeMusicComponent(MediaPlayerEntity):
 		self._debug_as_error = config.data.get(CONF_DEBUG_AS_ERROR, DEFAULT_DEBUG_AS_ERROR)
 		self._org_name = config.data.get(CONF_NAME, DOMAIN + name_add)
 		self._attr_name = self._org_name
+		self._api_language = config.data.get(CONF_API_LANGUAGE, DEFAULT_API_LANGUAGE)
 		self._init_extra_sensor = config.data.get(CONF_INIT_EXTRA_SENSOR, DEFAULT_INIT_EXTRA_SENSOR)
 		self._maxDatarate = config.data.get(CONF_MAX_DATARATE,DEFAULT_MAX_DATARATE)
 
@@ -347,7 +348,7 @@ class yTubeMusicComponent(MediaPlayerEntity):
 		if(self._api is None):
 			self.log_debug_later("- no valid API, try to login")
 			if(os.path.exists(self._header_file)):
-				[ret, msg, self._api] = await async_try_login(self.hass, self._header_file, self._brand_id)
+				[ret, msg, self._api] = await async_try_login(self.hass, self._header_file, self._brand_id, self._api_language)
 				if(msg != ""):
 					self._api = None
 					out = "Issue during login: " + msg

--- a/custom_components/ytube_music_player/translations/en.json
+++ b/custom_components/ytube_music_player/translations/en.json
@@ -14,6 +14,7 @@
                 "data": {
                     "speakers": "Select the default output device(s)",
                     "header_path": "File path for the header file",
+                    "api_language": "The language parameter of the ytmusicapi, which determines the language of the returned results",
                     "advance_config": "Show advance configuration"
                 }
             },
@@ -57,6 +58,7 @@
                 "data": {
                     "speakers": "Select the default output device",
                     "header_path": "File path for the header file",
+                    "api_language": "The language parameter of the ytmusicapi, which determines the language of the returned results",
                     "advance_config": "Show advance configuration"
                 }
             },


### PR DESCRIPTION
The default language for ytmusicapi is English. When searching for non-English content, the returned results remain in English. For non-English users, sometimes the returned results can be very unreasonable. These commits fixes this issue.

![image](https://github.com/KoljaWindeler/ytube_music_player/assets/69878862/8aa541ed-8a25-46c4-81d7-9a33e79edfbc)

When the language of ytmusicapi is not English, the category will return results in the selected language, causing the correction made in https://github.com/KoljaWindeler/ytube_music_player/pull/282 to be ineffective. The second commit can fix this issue.
