### PR TITLE
All entities are now automatically generated, along with some other changes.

### DIFF
--- a/custom_components/ytube_music_player/__init__.py
+++ b/custom_components/ytube_music_player/__init__.py
@@ -13,7 +13,13 @@ async def async_setup(hass, config):
 async def async_setup_entry(hass, config_entry):
 	"""Set up this integration using UI/YAML."""
 	hass.config_entries.async_update_entry(config_entry, data=ensure_config(config_entry.data))
-	config_entry.options = config_entry.data
+
+    # It might be unnecessary since the "options" in the config_entry is not being used.
+	# Additionally, due to the use of deprecated methods, 
+	# it resulted in the debug output described in 
+	# https://github.com/KoljaWindeler/ytube_music_player/issues/311.
+	# config_entry.options = config_entry.data
+
 	config_entry.add_update_listener(update_listener)
 
 	hass.data.setdefault(DOMAIN, {})
@@ -21,7 +27,7 @@ async def async_setup_entry(hass, config_entry):
 
 	# Add sensor
 	for platform in PLATFORMS:
-		hass.async_add_job(
+		hass.async_create_task(
 			hass.config_entries.async_forward_entry_setup(config_entry, platform)
 		)
 	return True
@@ -45,4 +51,4 @@ async def update_listener(hass, entry):
 	entry.data = entry.options
 	for platform in PLATFORMS:
 		await hass.config_entries.async_forward_entry_unload(entry, platform)
-		hass.async_add_job(hass.config_entries.async_forward_entry_setup(entry, platform))
+		hass.async_create_task(hass.config_entries.async_forward_entry_setup(entry, platform))

--- a/custom_components/ytube_music_player/config_flow.py
+++ b/custom_components/ytube_music_player/config_flow.py
@@ -216,10 +216,6 @@ async def async_create_form(hass, user_input, page=1):
 		data_schema[vol.Optional(CONF_TRACK_LIMIT, default=user_input[CONF_TRACK_LIMIT])] = vol.Coerce(int)
 		data_schema[vol.Optional(CONF_MAX_DATARATE, default=user_input[CONF_MAX_DATARATE])] = vol.Coerce(int)
 		data_schema[vol.Optional(CONF_BRAND_ID, default=user_input[CONF_BRAND_ID])] = str # brand id
-		data_schema[vol.Optional(CONF_SELECT_SPEAKERS, default=user_input[CONF_SELECT_SPEAKERS])] = str # drop down to select remote_player
-		data_schema[vol.Optional(CONF_SELECT_SOURCE, default=user_input[CONF_SELECT_SOURCE])] = str # drop down to select playlist / playlist-radio
-		data_schema[vol.Optional(CONF_SELECT_PLAYLIST, default=user_input[CONF_SELECT_PLAYLIST])] = str # drop down that holds the playlists
-		data_schema[vol.Optional(CONF_SELECT_PLAYCONTINUOUS, default=user_input[CONF_SELECT_PLAYCONTINUOUS])] = str # select of input_boolean -> continuous on/off
 
 		data_schema[vol.Optional(CONF_PROXY_PATH, default=user_input[CONF_PROXY_PATH])] = str # select of input_boolean -> continuous on/off
 		data_schema[vol.Optional(CONF_PROXY_URL, default=user_input[CONF_PROXY_URL])] = str # select of input_boolean -> continuous on/off

--- a/custom_components/ytube_music_player/config_flow.py
+++ b/custom_components/ytube_music_player/config_flow.py
@@ -10,6 +10,7 @@ import os
 import os.path
 from homeassistant.helpers.storage import STORAGE_DIR
 from ytmusicapi import YTMusic
+from ytmusicapi.helpers import SUPPORTED_LANGUAGES
 import requests
 from ytmusicapi.auth.oauth import OAuthCredentials, RefreshingToken
 
@@ -184,7 +185,7 @@ async def async_create_form(hass, user_input, page=1):
 	"""Create form for UI setup."""
 	user_input = ensure_config(user_input)
 	data_schema = OrderedDict()
-	languages = ["ar", "de", "en", "es", "fr", "hi", "it", "ja", "ko", "nl", "pt", "ru", "tr", "ur", "zh_CN", "zh_TW"]
+	languages = list(SUPPORTED_LANGUAGES)
 
 	if(page == 1):
 		data_schema[vol.Required(CONF_CODE+"TT", default="https://www.google.com/device?user_code="+user_input[CONF_CODE]["user_code"])] = str # name of the component without domain
@@ -200,7 +201,8 @@ async def async_create_form(hass, user_input, page=1):
 		data_schema[vol.Required(CONF_API_LANGUAGE, default=user_input[CONF_API_LANGUAGE])] = selector({
 				"select": {
 					"options": languages,
-					"mode": "dropdown"
+					"mode": "dropdown",
+					"sort": True
 				}
 			})
 		data_schema[vol.Required(CONF_HEADER_PATH, default=user_input[CONF_HEADER_PATH])] = str # file path of the header

--- a/custom_components/ytube_music_player/const.py
+++ b/custom_components/ytube_music_player/const.py
@@ -41,17 +41,11 @@ from homeassistant.components.media_player import (
 	DOMAIN as DOMAIN_MP,
 )
 
-from homeassistant.components.input_boolean import (
-	SERVICE_TURN_OFF as IB_OFF,
-	SERVICE_TURN_ON as IB_ON,
-	DOMAIN as DOMAIN_IB,
-)
-
-import homeassistant.components.input_select as input_select
-import homeassistant.components.input_boolean as input_boolean
+import homeassistant.components.select as select
+import homeassistant.components.switch as switch
 
 # Should be equal to the name of your component.
-PLATFORMS = {"media_player", "sensor"}
+PLATFORMS = {"sensor", "select", "media_player" }
 DOMAIN = "ytube_music_player"
 
 SUPPORT_YTUBEMUSIC_PLAYER = (
@@ -127,17 +121,6 @@ CONF_TRACK_LIMIT = 'track_limit'
 CONF_PROXY_URL = 'proxy_url'
 CONF_PROXY_PATH = 'proxy_path'
 
-CONF_SELECT_SOURCE = 'select_source'
-CONF_SELECT_PLAYLIST = 'select_playlist'
-CONF_SELECT_SPEAKERS = 'select_speakers'
-CONF_SELECT_PLAYMODE = 'select_playmode'
-CONF_SELECT_PLAYCONTINUOUS = 'select_playcontinuous'
-
-DEFAULT_SELECT_PLAYCONTINUOUS = "" #input_boolean.DOMAIN + "." + DOMAIN + '_playcontinuous' # cleared defaults to avoid further issues with multiple instances
-DEFAULT_SELECT_SOURCE = "" #input_select.DOMAIN + "." + DOMAIN + '_source'	 # cleared defaults to avoid further issues with multiple instances
-DEFAULT_SELECT_PLAYLIST = "" #input_select.DOMAIN + "." + DOMAIN + '_playlist' # cleared defaults to avoid further issues with multiple instances
-DEFAULT_SELECT_PLAYMODE = "" #input_select.DOMAIN + "." + DOMAIN + '_playmode' # cleared defaults to avoid further issues with multiple instances
-DEFAULT_SELECT_SPEAKERS = "" #input_select.DOMAIN + "." + DOMAIN + '_speakers' # cleared defaults to avoid further issues with multiple instances
 DEFAULT_HEADER_FILENAME = 'header_'
 DEFAULT_API_LANGUAGE = 'en'
 DEFAULT_LIKE_IN_NAME = False
@@ -231,10 +214,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend = vol.Schema({
 	DOMAIN: vol.Schema({
 		vol.Optional(CONF_RECEIVERS): cv.string,
 		vol.Optional(CONF_HEADER_PATH, default=DEFAULT_HEADER_FILENAME): cv.string,
-		vol.Optional(CONF_SELECT_SOURCE, default=DEFAULT_SELECT_SOURCE): cv.string,
-		vol.Optional(CONF_SELECT_PLAYLIST, default=DEFAULT_SELECT_PLAYLIST): cv.string,
-		vol.Optional(CONF_SELECT_PLAYMODE, default=DEFAULT_SELECT_PLAYMODE): cv.string,
-		vol.Optional(CONF_SELECT_SPEAKERS, default=DEFAULT_SELECT_SPEAKERS): cv.string,
 	})
 }, extra=vol.ALLOW_EXTRA)
 
@@ -318,11 +297,6 @@ def ensure_config(user_input):
 	out[CONF_RECEIVERS] = ''
 	out[CONF_SHUFFLE] = DEFAULT_SHUFFLE
 	out[CONF_SHUFFLE_MODE] = DEFAULT_SHUFFLE_MODE
-	out[CONF_SELECT_SOURCE] = DEFAULT_SELECT_SOURCE
-	out[CONF_SELECT_PLAYLIST] = DEFAULT_SELECT_PLAYLIST
-	out[CONF_SELECT_PLAYMODE] = DEFAULT_SELECT_PLAYMODE
-	out[CONF_SELECT_SPEAKERS] = DEFAULT_SELECT_SPEAKERS
-	out[CONF_SELECT_PLAYCONTINUOUS] = DEFAULT_SELECT_PLAYCONTINUOUS
 	out[CONF_PROXY_PATH] = ""
 	out[CONF_PROXY_URL] = ""
 	out[CONF_BRAND_ID] = ""

--- a/custom_components/ytube_music_player/media_player.py
+++ b/custom_components/ytube_music_player/media_player.py
@@ -300,10 +300,12 @@ class yTubeMusicComponent(MediaPlayerEntity):
 		self._attributes['_media_id'] = None
 
 		self.hass.data[DOMAIN][self._attr_unique_id]['lyrics'] = ""
-		self.hass.data[DOMAIN][self._attr_unique_id]['search'] = ""
+		# After turning off the media_player, keep the playlists and search information available
+		# as they may be needed forautomations.
+		# self.hass.data[DOMAIN][self._attr_unique_id]['search'] = ""
 		self.hass.data[DOMAIN][self._attr_unique_id]['tracks'] = ""
-		self.hass.data[DOMAIN][self._attr_unique_id]['playlists'] = ""
-		self.hass.data[DOMAIN][self._attr_unique_id]['total_tracks'] = ""
+		# self.hass.data[DOMAIN][self._attr_unique_id]['playlists'] = ""
+		self.hass.data[DOMAIN][self._attr_unique_id]['total_tracks'] = 0
 
 
 	async def async_update(self):

--- a/custom_components/ytube_music_player/media_player.py
+++ b/custom_components/ytube_music_player/media_player.py
@@ -15,8 +15,6 @@ from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.storage import STORAGE_DIR
 
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_FRIENDLY_NAME
-import homeassistant.components.input_select as input_select
-import homeassistant.components.input_boolean as input_boolean
 import homeassistant.components.media_player as media_player
 
 from pytube import YouTube # to generate cipher
@@ -499,7 +497,7 @@ class yTubeMusicComponent(MediaPlayerEntity):
 
 
 	async def async_turn_on(self, *args, **kwargs):
-		# Turn on the selected media_player from input_select
+		# Turn on the selected media_player from select
 		self.log_me('debug', "[S] TURNON")
 		self._started_by = "UI"
 
@@ -535,7 +533,7 @@ class yTubeMusicComponent(MediaPlayerEntity):
 		if(self._select_radioMode != ""):
 			_source = self.hass.states.get(self._select_radioMode)
 			if _source is None:
-				_LOGGER.error("- (%s) is not a valid input_select entity.", self._select_radioMode)
+				_LOGGER.error("- (%s) is not a valid select entity.", self._select_radioMode)
 				self.log_me('debug', "[E] (fail) TURNON")
 				return
 			if(_source.state == "Playlist"):
@@ -663,7 +661,7 @@ class yTubeMusicComponent(MediaPlayerEntity):
 			remote_player = DOMAIN_MP + "." + remote_player
 		# sets the current media_player from speaker select
 		elif(self._select_speaker != "" and await self.async_check_entity_exists(self._select_speaker, unavailable_is_ok=False)):  # drop down for player does exist .. double check!!
-			media_player_select = self.hass.states.get(self._select_speaker)  # Example: self.hass.states.get(input_select.gmusic_player_speakers)
+			media_player_select = self.hass.states.get(self._select_speaker)  # Example: self.hass.states.get(select.gmusic_player_speakers)
 			if media_player_select is None:
 				self.log_me('error', "(" + self._select_speaker + ") is not a valid select entity to get the player.")
 			else:

--- a/custom_components/ytube_music_player/media_player.py
+++ b/custom_components/ytube_music_player/media_player.py
@@ -1023,19 +1023,19 @@ class yTubeMusicComponent(MediaPlayerEntity):
 		self.log_me('debug', "[S] async_update_selects")
 		# -- all others -- #
 		if(not await self.async_check_entity_exists(self._select_playlist, unavailable_is_ok=False)):
-			self._select_playlist = select.DOMAIN + "." + self.hass.data[DOMAIN][self._attr_unique_id]['select_playlist']._attr_name # register select entity
+			self._select_playlist = self.hass.data[DOMAIN][self._attr_unique_id]['select_playlist'].entity_id  # register select entity
 			self.log_me('debug', "- playlist select: " + str(self._select_playlist) + " registered")
 		if(not await self.async_check_entity_exists(self._select_playMode, unavailable_is_ok=False)):
-			self._select_playMode = select.DOMAIN + "." + self.hass.data[DOMAIN][self._attr_unique_id]['select_playmode']._attr_name # register select entity
+			self._select_playMode = self.hass.data[DOMAIN][self._attr_unique_id]['select_playmode'].entity_id  # register select entity
 			self.log_me('debug', "- play mode select: " + str(self._select_playMode) + " registered")
 		if(not await self.async_check_entity_exists(self._select_repeatMode, unavailable_is_ok=False)):
-			self._select_repeatMode = select.DOMAIN + "." + self.hass.data[DOMAIN][self._attr_unique_id]['select_repeat']._attr_name # register select entity
+			self._select_repeatMode = self.hass.data[DOMAIN][self._attr_unique_id]['select_repeat'].entity_id  # register select entity
 			self.log_me('debug', "- repeat mode Select: " + str(self._select_repeatMode) + " registered")
 		if(not await self.async_check_entity_exists(self._select_speaker, unavailable_is_ok=False)):
-			self._select_speaker = select.DOMAIN + "." + self.hass.data[DOMAIN][self._attr_unique_id]['select_speaker']._attr_name # register select entity
+			self._select_speaker = self.hass.data[DOMAIN][self._attr_unique_id]['select_speaker'].entity_id  # register select entity
 			self.log_me('debug', "- speaker select: " + str(self._select_speaker) + " registered")
 		if(not await self.async_check_entity_exists(self._select_radioMode, unavailable_is_ok=False)):
-			self._select_radioMode = select.DOMAIN + "." + self.hass.data[DOMAIN][self._attr_unique_id]['select_radiomode']._attr_name # register select entity
+			self._select_radioMode = self.hass.data[DOMAIN][self._attr_unique_id]['select_radiomode'].entity_id  # register select entity
 			self.log_me('debug', "- radio mode Select: " + str(self._select_radioMode) + " registered")
 		# ----------- speaker -----#
 		try:

--- a/custom_components/ytube_music_player/media_player.py
+++ b/custom_components/ytube_music_player/media_player.py
@@ -864,7 +864,7 @@ class yTubeMusicComponent(MediaPlayerEntity):
 			_LOGGER.info("SHUFFLE_MODE: %s", self._shuffle_mode)
 
 		if event.data['shuffle']:
-			self.set_shuffle(event.data.get('shuffle'))
+			self.async_set_shuffle(event.data.get('shuffle'))
 			_LOGGER.info("- SHUFFLE: %s", self._shuffle)
 
 		self.log_me('debug', "- Speakers: (%s) | Source: (%s) | Name: (%s)", _speak, _source, _media)

--- a/custom_components/ytube_music_player/media_player.py
+++ b/custom_components/ytube_music_player/media_player.py
@@ -1023,20 +1023,20 @@ class yTubeMusicComponent(MediaPlayerEntity):
 		self.log_me('debug', "[S] async_update_selects")
 		# -- all others -- #
 		if(not await self.async_check_entity_exists(self._select_playlist, unavailable_is_ok=False)):
-			self.log_me('debug', "- playlist: " + str(self._select_playlist) + " not found")
 			self._select_playlist = select.DOMAIN + "." + self.hass.data[DOMAIN][self._attr_unique_id]['select_playlist']._attr_name # register select entity
+			self.log_me('debug', "- playlist select: " + str(self._select_playlist) + " registered")
 		if(not await self.async_check_entity_exists(self._select_playMode, unavailable_is_ok=False)):
-			self.log_me('debug', "- playmode: " + str(self._select_playMode) + " not found")
 			self._select_playMode = select.DOMAIN + "." + self.hass.data[DOMAIN][self._attr_unique_id]['select_playmode']._attr_name # register select entity
+			self.log_me('debug', "- play mode select: " + str(self._select_playMode) + " registered")
 		if(not await self.async_check_entity_exists(self._select_repeatMode, unavailable_is_ok=False)):
-			self.log_me('debug', "- playContinuous: " + str(self._select_repeatMode) + " not found")
 			self._select_repeatMode = select.DOMAIN + "." + self.hass.data[DOMAIN][self._attr_unique_id]['select_repeat']._attr_name # register select entity
+			self.log_me('debug', "- repeat mode Select: " + str(self._select_repeatMode) + " registered")
 		if(not await self.async_check_entity_exists(self._select_speaker, unavailable_is_ok=False)):
-			self.log_me('debug', "- mediaPlayer: " + str(self._select_speaker) + " not found")
 			self._select_speaker = select.DOMAIN + "." + self.hass.data[DOMAIN][self._attr_unique_id]['select_speaker']._attr_name # register select entity
+			self.log_me('debug', "- speaker select: " + str(self._select_speaker) + " registered")
 		if(not await self.async_check_entity_exists(self._select_radioMode, unavailable_is_ok=False)):
-			self.log_me('debug', "- Source: " + str(self._select_radioMode) + " not found")
 			self._select_radioMode = select.DOMAIN + "." + self.hass.data[DOMAIN][self._attr_unique_id]['select_radiomode']._attr_name # register select entity
+			self.log_me('debug', "- radio mode Select: " + str(self._select_radioMode) + " registered")
 		# ----------- speaker -----#
 		try:
 			if(isinstance(self._speakersList, str)):

--- a/custom_components/ytube_music_player/select.py
+++ b/custom_components/ytube_music_player/select.py
@@ -21,6 +21,7 @@ class yTubeMusicSelectEntity(SelectEntity):
 		self.hass = hass
 		self._device_id = config.entry_id
 		self._device_name = config.data.get(CONF_NAME)
+		self._attr_has_entity_name = True
 
 	def select_option(self, option):
 		"""Change the selected option."""
@@ -45,7 +46,7 @@ class yTubeMusicPlaylistSelect(yTubeMusicSelectEntity):
 	def __init__(self, hass, config):
 		super().__init__(hass, config)
 		self._attr_unique_id = self._device_id + "_playlist"
-		self._attr_name = config.data.get(CONF_NAME) + "_playlist"
+		self._attr_name = "Playlist"
 		self._attr_icon = 'mdi:playlist-music'
 		self.hass.data[DOMAIN][self._device_id]['select_playlist'] = self
 		self._attr_options = ["loading"]
@@ -71,7 +72,7 @@ class yTubeMusicSpeakerSelect(yTubeMusicSelectEntity):
 	def __init__(self, hass, config):
 		super().__init__(hass, config)
 		self._attr_unique_id = self._device_id + "_speaker"
-		self._attr_name = config.data.get(CONF_NAME) + "_speaker"
+		self._attr_name = "Speaker"
 		self._attr_icon = 'mdi:speaker'
 		self.hass.data[DOMAIN][self._device_id]['select_speaker'] = self
 		self._attr_options = ["loading"]
@@ -94,7 +95,7 @@ class yTubeMusicPlayModeSelect(yTubeMusicSelectEntity):
 	def __init__(self, hass, config):
 		super().__init__(hass, config)
 		self._attr_unique_id = self._device_id + "_playmode"
-		self._attr_name = config.data.get(CONF_NAME) + "_playmode"
+		self._attr_name = "Play Mode"
 		self._attr_icon = 'mdi:shuffle'
 		self.hass.data[DOMAIN][self._device_id]['select_playmode'] = self
 		self._attr_options = ["Shuffle","Random","Shuffle Random","Direct"]
@@ -105,7 +106,7 @@ class yTubeMusicSourceSelect(yTubeMusicSelectEntity):
 	def __init__(self, hass, config):
 		super().__init__(hass, config)
 		self._attr_unique_id = self._device_id + "_radiomode"
-		self._attr_name = config.data.get(CONF_NAME) + "_radiomode"
+		self._attr_name = "Radio Mode"
 		self._attr_icon = 'mdi:music-box-multiple'
 		self.hass.data[DOMAIN][self._device_id]['select_radiomode'] = self
 		self._attr_options = ["Playlist","Playlist Radio"] # "Playlist" means not radio mode
@@ -116,7 +117,7 @@ class yTubeMusicRepeatSelect(yTubeMusicSelectEntity):
 	def __init__(self, hass, config):
 		super().__init__(hass, config)
 		self._attr_unique_id = self._device_id + "_repeat"
-		self._attr_name = config.data.get(CONF_NAME) + "_repeat"
+		self._attr_name = "Repeat Mode"
 		self._attr_icon = 'mdi:repeat'
 		self.hass.data[DOMAIN][self._device_id]['select_repeat'] = self
 		self._attr_options = ["all", "one", "off"]  # one for future

--- a/custom_components/ytube_music_player/select.py
+++ b/custom_components/ytube_music_player/select.py
@@ -1,0 +1,123 @@
+"""Platform for sensor integration."""
+import logging
+from homeassistant.components.select import SelectEntity
+from homeassistant.exceptions import NoEntitySpecifiedError
+from . import DOMAIN
+from .const import *
+
+_LOGGER = logging.getLogger(__name__)
+
+async def async_setup_entry(hass, config, async_add_entities):
+	entities = []
+	entities.append(yTubeMusicPlaylistSelect(hass, config))
+	entities.append(yTubeMusicSpeakerSelect(hass, config))
+	entities.append(yTubeMusicPlayModeSelect(hass, config))
+	entities.append(yTubeMusicSourceSelect(hass, config))
+	entities.append(yTubeMusicRepeatSelect(hass, config))
+	async_add_entities(entities, update_before_add=True)
+
+class yTubeMusicSelectEntity(SelectEntity):
+	def __init__(self, hass, config):
+		self.hass = hass
+		self._device_id = config.entry_id
+		self._device_name = config.data.get(CONF_NAME)
+
+	def select_option(self, option):
+		"""Change the selected option."""
+		self._attr_current_option = option
+		self.async_write_ha_state()
+
+	@property
+	def device_info(self):
+		return {
+			'identifiers': {(DOMAIN, self._device_id)},
+			'name': self._device_name,
+			'manufacturer': "Google Inc.",
+			'model': DOMAIN
+		}
+
+	@property
+	def should_poll(self):
+		return False
+
+
+class yTubeMusicPlaylistSelect(yTubeMusicSelectEntity):
+	def __init__(self, hass, config):
+		super().__init__(hass, config)
+		self._attr_unique_id = self._device_id + "_playlist"
+		self._attr_name = config.data.get(CONF_NAME) + "_playlist"
+		self._attr_icon = 'mdi:playlist-music'
+		self.hass.data[DOMAIN][self._device_id]['select_playlist'] = self
+		self._attr_options = ["loading"]
+		self._attr_current_option = None
+
+	async def async_update(self):
+		# update select
+		self._ready = True
+		try:
+			als = []
+			for playlist in self.hass.data[DOMAIN][self._device_id]['playlists']:
+				als.append(playlist)
+			self._attr_options = als
+		except:
+			pass
+		try:
+			self.async_schedule_update_ha_state()
+		except NoEntitySpecifiedError:
+			pass  # we ignore this due to a harmless startup race condition
+
+
+class yTubeMusicSpeakerSelect(yTubeMusicSelectEntity):
+	def __init__(self, hass, config):
+		super().__init__(hass, config)
+		self._attr_unique_id = self._device_id + "_speaker"
+		self._attr_name = config.data.get(CONF_NAME) + "_speaker"
+		self._attr_icon = 'mdi:speaker'
+		self.hass.data[DOMAIN][self._device_id]['select_speaker'] = self
+		self._attr_options = ["loading"]
+		self._attr_current_option = None
+
+	async def async_update(self, options=[]):
+		# update select
+		self._ready = True
+		try:
+			self._attr_options = options
+		except:
+			pass
+		try:
+			self.async_schedule_update_ha_state()
+		except NoEntitySpecifiedError:
+			pass  # we ignore this due to a harmless startup race condition
+
+
+class yTubeMusicPlayModeSelect(yTubeMusicSelectEntity):
+	def __init__(self, hass, config):
+		super().__init__(hass, config)
+		self._attr_unique_id = self._device_id + "_playmode"
+		self._attr_name = config.data.get(CONF_NAME) + "_playmode"
+		self._attr_icon = 'mdi:shuffle'
+		self.hass.data[DOMAIN][self._device_id]['select_playmode'] = self
+		self._attr_options = ["Shuffle","Random","Shuffle Random","Direct"]
+		self._attr_current_option = "Shuffle Random"
+
+
+class yTubeMusicSourceSelect(yTubeMusicSelectEntity):
+	def __init__(self, hass, config):
+		super().__init__(hass, config)
+		self._attr_unique_id = self._device_id + "_radiomode"
+		self._attr_name = config.data.get(CONF_NAME) + "_radiomode"
+		self._attr_icon = 'mdi:music-box-multiple'
+		self.hass.data[DOMAIN][self._device_id]['select_radiomode'] = self
+		self._attr_options = ["Playlist","Playlist Radio"] # "Playlist" means not radio mode
+		self._attr_current_option = "Playlist"
+
+
+class yTubeMusicRepeatSelect(yTubeMusicSelectEntity):
+	def __init__(self, hass, config):
+		super().__init__(hass, config)
+		self._attr_unique_id = self._device_id + "_repeat"
+		self._attr_name = config.data.get(CONF_NAME) + "_repeat"
+		self._attr_icon = 'mdi:repeat'
+		self.hass.data[DOMAIN][self._device_id]['select_repeat'] = self
+		self._attr_options = ["all", "one", "off"]  # one for future
+		self._attr_current_option = "all"

--- a/custom_components/ytube_music_player/sensor.py
+++ b/custom_components/ytube_music_player/sensor.py
@@ -9,11 +9,11 @@ from .const import *
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_entry(hass, config, async_add_devices):
+async def async_setup_entry(hass, config, async_add_entities):
 	# Run setup via Storage
 	_LOGGER.debug("Config via Storage/UI")
 	if(config.data.get(CONF_INIT_EXTRA_SENSOR, DEFAULT_INIT_EXTRA_SENSOR)):
-		async_add_devices([yTubeMusicSensor(hass, config)], update_before_add=True)
+		async_add_entities([yTubeMusicSensor(hass, config)], update_before_add=True)
 
 
 class yTubeMusicSensor(Entity):
@@ -23,11 +23,13 @@ class yTubeMusicSensor(Entity):
 		# Initialize the sensor.
 		self.hass = hass
 		self._state = STATE_OFF
-		self._attr_unique_id = config.entry_id
+		self._device_id = config.entry_id
 		self._device_name = config.data.get(CONF_NAME)
-		self._attr_name = config.data.get(CONF_NAME) + "_extra"
+		self._attr_unique_id = config.entry_id + "_extra"  # should be different from the media_player entity
+		self._attr_has_entity_name = True
+		self._attr_name = "Extra"
 		self._attr_icon = 'mdi:information-outline'
-		self.hass.data[DOMAIN][self._attr_unique_id]['extra_sensor'] = self
+		self.hass.data[DOMAIN][self._device_id]['extra_sensor'] = self
 		self._attr = {'tracks', 'search', 'lyrics', 'playlists', 'total_tracks'}
 		self._attributes = {}
 		for attr in self._attr:
@@ -38,7 +40,7 @@ class yTubeMusicSensor(Entity):
 	@property
 	def device_info(self):
 		return {
-			'identifiers': {(DOMAIN, self._attr_unique_id)},
+			'identifiers': {(DOMAIN, self._device_id)},
 			'name': self._device_name,
 			'manufacturer': "Google Inc.",
 			'model': DOMAIN
@@ -66,8 +68,8 @@ class yTubeMusicSensor(Entity):
 
 		# update all attributes from the data var
 		for attr in self._attr:
-			if attr in self.hass.data[DOMAIN][self._attr_unique_id]:
-				self._attributes[attr] = self.hass.data[DOMAIN][self._attr_unique_id][attr]
+			if attr in self.hass.data[DOMAIN][self._device_id]:
+				self._attributes[attr] = self.hass.data[DOMAIN][self._device_id][attr]
 
 		try:
 			self.async_schedule_update_ha_state()

--- a/custom_components/ytube_music_player/translations/en.json
+++ b/custom_components/ytube_music_player/translations/en.json
@@ -12,21 +12,16 @@
             "finish": {
                 "description": "Please enter the basic data. Further information available at https://github.com/KoljaWindeler/ytube_music_player",
                 "data": {
-                    "speakers": "Select the default output device(s)",
+                    "speakers": "Select the output devices, the first one will be the default device",
                     "header_path": "File path for the header file",
                     "api_language": "The language parameter of the ytmusicapi, which determines the language of the returned results",
                     "advance_config": "Show advance configuration"
                 }
             },
             "adv_finish": {
-                "description": "Here you can change to entity ids of select fields, if you don't use the dropdowns just leave them as is",
+                "description": "You can configure some behaviors of the player here, such as limiting data usage and setting the maximum number of tracks loaded per session.",
                 "data": {
                     "brand_id": "Enter a brand id if you are using a brand account",
-                    "select_speakers": "Entity id of input_select for speaker selection",
-                    "select_playmode":"Entity id of input_select for playmode selection",
-                    "select_source":"Entity id of input_select for playlist/radio selection",
-                    "select_playlist":"Entity id of input_select for playlist selection",
-                    "select_playcontinuous":"Entity id of input_boolean for play continouus selection",
                     "proxy_path": "Local path for proxy mode, leave blank if you don't need it",
                     "proxy_url": "Base URL for proxy mode, leave blank if you don't need it",
                     "like_in_name": "Show like status in the name",
@@ -56,21 +51,16 @@
             "finish": {
                 "description": "Please enter the basic data. Further information available at https://github.com/KoljaWindeler/ytube_music_player",
                 "data": {
-                    "speakers": "Select the default output device",
+                    "speakers": "Select the output devices, the first one will be the default device",
                     "header_path": "File path for the header file",
                     "api_language": "The language parameter of the ytmusicapi, which determines the language of the returned results",
                     "advance_config": "Show advance configuration"
                 }
             },
             "adv_finish": {
-                "description": "Here you can change to entity ids of select fields, if you don't use the dropdowns just leave them as is",
+                "description": "You can configure some behaviors of the player here, such as limiting data usage and setting the maximum number of tracks loaded per session.",
                 "data": {
                     "brand_id": "Enter a brand id if you are using a brand account",
-                    "select_speakers": "Entity id of input_select for speaker selection",
-                    "select_playmode":"Entity id of input_select for playmode selection",
-                    "select_source":"Entity id of input_select for playlist/radio selection",
-                    "select_playlist":"Entity id of input_select for playlist selection",
-                    "select_playcontinuous":"Entity id of input_boolean for play continouus selection",
                     "proxy_path": "Local path for proxy mode, leave blank if you don't need it",
                     "proxy_url": "Base URL for proxy mode, leave blank if you don't need it",
                     "like_in_name": "Show like status in the name",

--- a/custom_components/ytube_music_player/translations/zh-Hans.json
+++ b/custom_components/ytube_music_player/translations/zh-Hans.json
@@ -10,23 +10,18 @@
                 }
             },
             "finish": {
-                "description": "请输入基本信息。需要帮助请查看https://github.com/KoljaWindeler/ytube_music_player",
+                "description": "在这里进行基本设置。需要帮助请查看https://github.com/KoljaWindeler/ytube_music_player",
                 "data": {
-                    "speakers": "播放设备白名单",
+                    "speakers": "选择输出设备白名单，第一个是默认设备。",
                     "header_path": "header文件保存路径",
                     "api_language": "API返回结果语言",
                     "advance_config": "显示高级选项"
                 }
             },
             "adv_finish": {
-                "description": "你可以在这里更改下拉菜单的实体ID，如果不使用下拉菜单，请将它们保持不变",
+                "description": "在这里进行高级设置，比如限制流量使用和单次加载的最大曲目数。",
                 "data": {
                     "brand_id": "如果您正在使用brand account，请输入brand id",
-                    "select_speakers": "播放设备下拉菜单实体ID",
-                    "select_playmode":"循环模式下拉菜单实体ID",
-                    "select_source":"播放列表/电台选择下拉菜单实体ID",
-                    "select_playlist":"播放列表下拉菜单实体ID",
-                    "select_playcontinuous":"持续播放模式下拉菜单实体ID",
                     "proxy_path": "代理模式的本地路径，不需要请留空",
                     "proxy_url": "代理服务器地址，不需要请留空",
                     "like_in_name": "在名称中显示喜欢状态",
@@ -54,23 +49,18 @@
                 }
             },
             "finish": {
-                "description": "请输入基本信息。需要帮助请查看https://github.com/KoljaWindeler/ytube_music_player",
+                "description": "在这里进行基本设置。需要帮助请查看https://github.com/KoljaWindeler/ytube_music_player",
                 "data": {
-                    "speakers": "播放设备白名单",
+                    "speakers": "选择输出设备白名单，第一个是默认设备。",
                     "header_path": "header文件保存路径",
                     "api_language": "API返回结果语言",
                     "advance_config": "显示高级选项"
                 }
             },
             "adv_finish": {
-                "description": "你可以在这里更改下拉菜单的实体ID，如果不使用下拉菜单，请将它们保持不变",
+                "description": "在这里进行高级设置，比如限制流量使用和单次加载的最大曲目数。",
                 "data": {
                     "brand_id": "如果您正在使用brand account，请输入brand id",
-                    "select_speakers": "播放设备下拉菜单实体ID",
-                    "select_playmode":"循环模式下拉菜单实体ID",
-                    "select_source":"播放列表/电台选择下拉菜单实体ID",
-                    "select_playlist":"播放列表下拉菜单实体ID",
-                    "select_playcontinuous":"持续播放模式下拉菜单实体ID",
                     "proxy_path": "代理模式的本地路径，不需要请留空",
                     "proxy_url": "代理服务器地址，不需要请留空",
                     "like_in_name": "在名称中显示喜欢状态",


### PR DESCRIPTION
Hi @KoljaWindeler !
After this submit, all entities will be automatically generated, which will be beneficial for  multiple accounts or instances.Below are some specific details of this submit:
1.Add select entities to replace the input_select entities configured via YAML.
2.Adjust service calls.
3.Remove unnecessary variables, constants, and imports.
4.Update config_flow.
5.Update Simplified Chinese and English language.
![image](https://github.com/KoljaWindeler/ytube_music_player/assets/69878862/0c1928ed-baa8-436d-8a82-10c36626a7cf)
Additionally, there are some other modifications:

1.The first speake selected by the user in the config flow will be set as the default one.
2.Fix the call to the non-existent set_shuffle method (should be async_set_shuffle).
3.Change some variable names .

I'm sorry for the extensive changes in this submission, especially since some of the content is unrelated to generating the select entities. Thank you for reviewing.