### PR TITLE
updated ytmusicapi to 1.12.1

### DIFF
--- a/custom_components/ytube_music_player/manifest.json
+++ b/custom_components/ytube_music_player/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/KoljaWindeler/ytube_music_player/issues",
   "requirements": [
-    "ytmusicapi==1.9.1",
+    "ytmusicapi==1.12.1",
     "pytubefix>=10.7.2",
     "integrationhelper==0.2.2"
   ],


### PR DESCRIPTION
updated ytmusicapi to 1.12.1 to fix issue on newer versions Traceback (most recent call last):
  File "<python-input-0>", line 1, in <module>
    ytmusic.get_watch_playlist("GrmqhxiaVsQ")
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/usr/lib/python3.14/site-packages/ytmusicapi/mixins/watch.py", line 153, in get_watch_playlist
    related_browse_id = get_tab_browse_id(watchNextRenderer, 2)
  File "/usr/lib/python3.14/site-packages/ytmusicapi/parsers/watch.py", line 68, in get_tab_browse_id
    str, watchNextRenderer["tabs"][tab_id]["tabRenderer"]["endpoint"]["browseEndpoint"]["browseId"]
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
KeyError: 'endpoint'